### PR TITLE
build from v1.2-debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluent/fluentd:v1.2
+FROM fluent/fluentd:v1.2-debian
 
 COPY ./rootfs .
 


### PR DESCRIPTION
## What
Base the image from `fluentd:v1.2-debian`

## Why
| We recommend to use debian version for production because it uses jemalloc to mitigate memory fragmentation issue.
https://hub.docker.com/r/fluent/fluentd/

Also should resolve this issue: https://github.com/fluent/fluentd/issues/1237